### PR TITLE
CLI improvements: add --gallery option, fix --list-palettes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ console.log('Sunset colors:', PALETTES.sunset);
 | `-d, --direction <dir>` | Gradient direction (`vertical`, `horizontal`, `diagonal`) | `vertical` |
 | `--filled` | Use filled block characters instead of outlined ASCII | `false` |
 | `-l, --list-palettes` | Show all available color palettes | - |
+| `--gallery` | Render text in all available palettes | - |
 | `--color` | Force color output (useful for pipes) | - |
 | `--no-color` | Disable color output | - |
 | `-v, --version` | Show version number | - |
@@ -203,6 +204,22 @@ npx oh-my-logo "DEPLOY SUCCESS" forest --color
 
 # Plain text output
 npx oh-my-logo "LOG ENTRY" --no-color
+```
+
+### Gallery Mode
+
+```bash
+# Display text in all available palettes
+npx oh-my-logo "PREVIEW" --gallery
+
+# Gallery with filled characters
+npx oh-my-logo "COLORS" --gallery --filled
+
+# Compare multi-line text across all palettes
+npx oh-my-logo "MY\nLOGO" --gallery
+
+# Gallery with custom font
+npx oh-my-logo "STYLES" --gallery -f Big
 ```
 
 ## 🎭 Use Cases

--- a/README.md
+++ b/README.md
@@ -295,6 +295,38 @@ npm run build
 node dist/index.js "HELLO" matrix --filled
 ```
 
+### 🧪 Testing
+
+Run the test suite with Vitest:
+
+```bash
+# Run all tests in watch mode
+npm run test
+
+# Run tests once (CI mode)
+npm run test:coverage
+
+# Run tests with UI
+npm run test:ui
+
+# Run specific test file
+npm test -- src/__tests__/cli.test.ts
+```
+
+The test suite includes:
+- Unit tests for all library functions
+- CLI integration tests
+- Color palette validation
+- Error handling scenarios
+- TTY/color detection logic
+
+Tests are located in `src/__tests__/` with the following structure:
+- `cli.test.ts` - CLI command line behavior
+- `lib.test.ts` - Library API functions
+- `palettes.test.ts` - Color palette system
+- `renderer.test.ts` - ASCII art rendering
+- `utils/` - Utility function tests
+
 ### Adding New Palettes
 
 Edit `src/palettes.ts` to add your own color combinations:

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const cliPath = join(__dirname, '..', '..', 'src', 'index.ts');
+
+describe('CLI', () => {
+  let originalExit: typeof process.exit;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    // Mock process.exit to capture exit codes
+    originalExit = process.exit;
+    exitCode = undefined;
+    process.exit = vi.fn((code?: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as any;
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+  });
+
+  describe('--list-palettes', () => {
+    it('should list palettes without requiring text argument', () => {
+      try {
+        const output = execSync(`npx tsx ${cliPath} --list-palettes`, { encoding: 'utf-8' });
+        expect(output).toContain('Available palettes:');
+        expect(output).toContain('sunset');
+        expect(output).toContain('ocean');
+        expect(output).toContain('fire');
+      } catch (error: any) {
+        // If the command fails, it should not be due to missing text argument
+        expect(error.message).not.toContain('missing required argument');
+        expect(error.message).not.toContain('text');
+      }
+    });
+
+    it('should work with -l short option', () => {
+      try {
+        const output = execSync(`npx tsx ${cliPath} -l`, { encoding: 'utf-8' });
+        expect(output).toContain('Available palettes:');
+      } catch (error: any) {
+        // If the command fails, it should not be due to missing text argument
+        expect(error.message).not.toContain('missing required argument');
+        expect(error.message).not.toContain('text');
+      }
+    });
+  });
+
+  describe('text argument', () => {
+    it('should require text argument when not using --list-palettes', () => {
+      try {
+        execSync(`npx tsx ${cliPath}`, { encoding: 'utf-8', stdio: 'pipe' });
+        // Should not reach here
+        expect(true).toBe(false);
+      } catch (error: any) {
+        // Should fail with appropriate error
+        expect(error.stderr || error.message).toMatch(/text is required|missing required argument/i);
+      }
+    });
+
+    it('should accept text argument for normal operation', () => {
+      try {
+        const output = execSync(`npx tsx ${cliPath} "TEST" --no-color`, { encoding: 'utf-8' });
+        // The output should contain ASCII art (not the literal word TEST)
+        expect(output.length).toBeGreaterThan(0);
+        expect(output).toMatch(/[_|\/\\]/); // ASCII art characters
+      } catch (error: any) {
+        // If it fails, log the error for debugging
+        console.error('Error running CLI with text:', error.message);
+        throw error;
+      }
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ program
   .name('oh-my-logo')
   .description('Display giant ASCII art logos with colorful gradients in your terminal')
   .version(packageJson.version)
-  .argument('<text>', 'Text to display (use "\\n" for newlines or "-" for stdin)')
+  .argument('[text]', 'Text to display (use "\\n" for newlines or "-" for stdin)')
   .argument('[palette]', 'Color palette to use', DEFAULT_PALETTE)
   .option('-f, --font <name>', 'Figlet font name', process.env.OHMYLOGO_FONT || DEFAULT_FONT)
   .option('-l, --list-palettes', 'List available palettes')
@@ -26,7 +26,7 @@ program
   .option('--no-color', 'Disable color output')
   .option('-d, --direction <dir>', 'Gradient direction: horizontal, vertical, or diagonal', 'vertical')
   .option('--filled', 'Use filled characters instead of outlined ASCII art')
-  .action(async (text: string, paletteArg: string, options) => {
+  .action(async (text: string | undefined, paletteArg: string, options) => {
     try {
       if (options.listPalettes) {
         console.log('Available palettes:');
@@ -37,6 +37,10 @@ program
         process.exit(0);
       }
 
+      if (!text) {
+        throw new InputError('Text is required when not using --list-palettes');
+      }
+      
       let inputText = text;
       
       if (text === '-') {


### PR DESCRIPTION
Great library! Helping out a little here.

# Fix - listing palettes

`--list-palettes` should work even if we don't pass in a text to render

# New - gallery mode to show text in all palettes

## Demo

cropped, just showing first 3 of output

<img width="218" height="960" alt="image" src="https://github.com/user-attachments/assets/864c60f0-bc10-475e-859f-fecdce9cffe2" />

# Tests

Ran all available tests, added tests for new/fixed areas. Everything passes.

Caveat: I'm a lifelong Python dev, I enlisted AI to help with making this TypeScript change. Not entirely vibe coded, the AI was on a short leash for every diff step.