### PR TITLE
chore(license): dual‑license project (MIT AND CC0‑1.0) & clarify logo CC0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+SPDX-License-Identifier: MIT AND CC0-1.0
+
+AI provenance notice:
+Portions generated with Anthropic Claude are dedicated to the
+public domain under CC0‑1.0; all copyright‑eligible code remains under MIT.
+
 MIT License
 
 Copyright (c) 2025 Yuki Shindo

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ You can also create stunning animations like these by using it as a library in y
 
 ![GIF Demo 2](./images/demo2.gif)
 
+The logos produced by `oh-my-logo` are CC0 (public domain); feel free to use them anywhere.
+
 ## ✨ Features
 
 - 🎨 **Two Rendering Modes**: Choose between outlined ASCII art or filled block characters
@@ -366,7 +368,7 @@ Contributions are welcome! Please feel free to submit a Pull Request. Whether it
 
 ## 📄 License
 
-MIT
+MIT AND CC0-1.0
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "figlet"
   ],
   "author": "shinshin86 <shinshin86npm@gmail.com> (https://github.com/shinshin86)",
-  "license": "MIT",
+  "license": "MIT AND CC0-1.0",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Why
The project now contains a small amount of code that was originally generated with Anthropic Claude.  
Purely machine‑generated fragments may lack copyright protection, so adding only an MIT license could leave their legal status unclear. To close that gap—and to make corporate compliance scanners happy—we are formally dual‑licensing:

* **Human‑authored, copyright‑eligible code** → **MIT**
* **AI‑generated fragments that lack sufficient human authorship** → **CC0‑1.0 (public domain)**

## What changed
* prepended SPDX header `MIT AND CC0-1.0` to **LICENSE**
* added *AI provenance notice* explaining the split
* updated **package.json** `license` field to the same SPDX expression
* updated **README** to state that any logos generated by `oh‑my‑logo` are released under CC0

## Impact on users
* **No new restrictions.**  
  - You can still use, modify, and redistribute the tool under MIT terms.  
  - AI‑generated parts are now explicitly public‑domain (CC0), which is even more permissive.  
* Generated ASCII/ANSI logos remain **CC0**, so they can be used commercially without attribution.