### PR TITLE
release 0.3.0 - add support for shadows, letter spacing, gradient reverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The logos produced by `oh-my-logo` are CC0 (public domain); feel free to use the
 - 🔤 **Multi-line Support**: Create logos with multiple lines of text
 - ⚡ **Zero Dependencies**: Run instantly with `npx` - no installation required
 - 🎛️ **Customizable**: Use different fonts and create your own color schemes
+- 🎭 **Shadow Styles**: Customize shadow effects in filled mode with different block fonts
+- 🔄 **Letter Spacing**: For `--filled` mode: character spacing for different visual densities
+- 🔄 **Reverse Gradients**: Flip color palettes for unique effects
 
 ## 🚀 Quick Start
 
@@ -33,6 +36,38 @@ Want filled characters? Add the `--filled` flag:
 
 ```bash
 npx oh-my-logo "YOUR LOGO" sunset --filled
+```
+
+### 🆕 New in v0.3.0
+
+**Customize shadow styles in filled mode:**
+```bash
+# Box-drawing shadows (default)
+npx oh-my-logo "STYLE" fire --filled --block-font block
+
+# Minimal sleek shadows
+npx oh-my-logo "STYLE" fire --filled --block-font chrome
+
+# Dotted/shaded shadows
+npx oh-my-logo "STYLE" fire --filled --block-font shade
+```
+
+**Control letter spacing for block fonts:**
+```bash
+# Wide spacing (5 spaces between letters)
+npx oh-my-logo "WIDE" ocean --filled --letter-spacing 5
+
+# Tight spacing (no spaces)
+npx oh-my-logo "TIGHT" ocean --filled --letter-spacing 0
+```
+
+**Reverse gradients for unique effects:**
+```bash
+# Reverse any color palette
+npx oh-my-logo "REVERSE" sunset --reverse-gradient
+
+# Works with filled mode too
+npx oh-my-logo "REVERSE" sunset --filled --reverse-gradient
 ```
 
 ## 📦 Installation
@@ -85,6 +120,18 @@ await renderFilled('AWESOME', {
   palette: 'fire'
 });
 
+// Filled with custom shadow style
+await renderFilled('SHADOW', {
+  palette: 'sunset',
+  font: 'shade'  // Use dotted shadow effect
+});
+
+// Filled with wide letter spacing
+await renderFilled('WIDE', {
+  palette: 'fire',
+  letterSpacing: 3
+});
+
 // TypeScript usage
 import { render, RenderOptions, PaletteName } from 'oh-my-logo';
 
@@ -116,6 +163,9 @@ console.log('Sunset colors:', PALETTES.sunset);
 | `-f, --font <name>` | Figlet font name | `Standard` |
 | `-d, --direction <dir>` | Gradient direction (`vertical`, `horizontal`, `diagonal`) | `vertical` |
 | `--filled` | Use filled block characters instead of outlined ASCII | `false` |
+| `--block-font <font>` | Font for filled mode (`block`, `chrome`, `shade`, `simpleBlock`, `3d`) | `block` |
+| `--letter-spacing <n>` | Letter spacing for filled mode (integer spaces between characters, 0+) | `1` |
+| `--reverse-gradient` | Reverse gradient colors | `false` |
 | `-l, --list-palettes` | Show all available color palettes | - |
 | `--gallery` | Render text in all available palettes | - |
 | `--color` | Force color output (useful for pipes) | - |
@@ -170,6 +220,99 @@ npx oh-my-logo "CODE" fire
 
 # Filled block characters
 npx oh-my-logo "CODE" fire --filled
+
+# Filled with different shadow styles
+npx oh-my-logo "CODE" fire --filled --block-font chrome   # Minimal box shadows
+npx oh-my-logo "CODE" fire --filled --block-font shade    # Dotted shadow effect
+npx oh-my-logo "CODE" fire --filled --block-font simpleBlock # Simple ASCII shadows
+```
+
+### Shadow Styles (--filled mode only)
+
+Customize the shadow characters in filled mode with `--block-font`:
+
+#### Visual Comparison of Shadow Styles
+
+**`block` (default)** - Box-drawing shadows:
+```
+ ██╗  ██╗ ██╗
+ ██║  ██║ ██║
+ ███████║ ██║
+ ██╔══██║ ██║
+ ██║  ██║ ██║
+ ╚═╝  ╚═╝ ╚═╝
+```
+
+**`chrome`** - Minimal sleek shadows:
+```
+ ╦ ╦ ╦
+ ╠═╣ ║
+ ╩ ╩ ╩
+```
+
+**`shade`** - Dotted shadow effect:
+```
+░░░░░░░░░
+░█░░█░███
+░█░░█░ █
+░████░░█
+░█  █░░█
+░█░░█░███
+░ ░░ ░
+░░░░░░░░░
+```
+
+**`simpleBlock`** - Basic ASCII shadows:
+```
+  _|    _|  _|_|_|
+  _|    _|    _|
+  _|_|_|_|    _|
+  _|    _|    _|
+  _|    _|  _|_|_|
+```
+
+```bash
+# Try different shadow styles
+npx oh-my-logo "SHADOW" sunset --filled --block-font block
+npx oh-my-logo "SHADOW" sunset --filled --block-font chrome
+npx oh-my-logo "SHADOW" sunset --filled --block-font shade
+npx oh-my-logo "SHADOW" sunset --filled --block-font simpleBlock
+```
+
+### Letter Spacing Control
+
+Adjust the spacing between characters for different visual densities:
+
+```bash
+# Default spacing (1 space)
+npx oh-my-logo "HI" --filled
+# Output:  ██╗  ██╗
+
+# Wide spacing (3 spaces)
+npx oh-my-logo "HI" --filled --letter-spacing 3
+# Output:  ██╗   ██╗
+
+# No spacing (touching)
+npx oh-my-logo "HI" --filled --letter-spacing 0  
+# Output: ██╗██╗
+
+# Note: Decimals are truncated (3.7 becomes 3)
+npx oh-my-logo "HI" --filled --letter-spacing 3.7  # Uses 3 spaces
+```
+
+### Reverse Gradient Effect
+
+Flip any color palette for unique visual effects:
+
+```bash
+# Normal sunset gradient (red → orange)
+npx oh-my-logo "GRADIENT" sunset
+
+# Reversed sunset gradient (orange → red)
+npx oh-my-logo "GRADIENT" sunset --reverse-gradient
+
+# Works with filled mode too
+npx oh-my-logo "GRADIENT" sunset --filled --reverse-gradient
 ```
 
 ### Gradient Directions
@@ -266,6 +409,8 @@ async function renderFilled(text: string, options?: RenderInkOptions): Promise<v
 
 - **text** (string): Text to display
 - **options.palette** (PaletteName | string[]): Color palette name or custom colors
+- **options.font** (BlockFont): Shadow style ('block' | 'chrome' | 'shade' | 'simpleBlock' | '3d')
+- **options.letterSpacing** (number): Integer number of spaces between characters (0 or greater, default: 1)
 
 Returns: `Promise<void>` - Renders directly to stdout
 
@@ -290,8 +435,13 @@ interface RenderOptions {
   direction?: 'vertical' | 'horizontal' | 'diagonal';
 }
 
+type BlockFont = 'block' | 'chrome' | 'shade' | 'simpleBlock' | '3d' | 
+                 'simple3d' | 'slick' | 'tiny' | 'grid' | 'pallet' | 'huge';
+
 interface RenderInkOptions {
   palette?: PaletteName | string[];
+  font?: BlockFont;
+  letterSpacing?: number;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -435,8 +435,9 @@ interface RenderOptions {
   direction?: 'vertical' | 'horizontal' | 'diagonal';
 }
 
-type BlockFont = 'block' | 'chrome' | 'shade' | 'simpleBlock' | '3d' | 
-                 'simple3d' | 'slick' | 'tiny' | 'grid' | 'pallet' | 'huge';
+type BlockFont = '3d' | 'block' | 'chrome' | 'console' | 'grid' | 
+                 'huge' | 'pallet' | 'shade' | 'simple' | 'simple3d' | 
+                 'simpleBlock' | 'slick' | 'tiny';
 
 interface RenderInkOptions {
   palette?: PaletteName | string[];

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ console.log('Sunset colors:', PALETTES.sunset);
 | `-f, --font <name>` | Figlet font name | `Standard` |
 | `-d, --direction <dir>` | Gradient direction (`vertical`, `horizontal`, `diagonal`) | `vertical` |
 | `--filled` | Use filled block characters instead of outlined ASCII | `false` |
-| `--block-font <font>` | Font for filled mode (`block`, `chrome`, `shade`, `simpleBlock`, `3d`) | `block` |
+| `--block-font <font>` | Font for filled mode (`3d`, `block`, `chrome`, `grid`, `huge`, `pallet`, `shade`, `simple`, `simple3d`, `simpleBlock`, `slick`, `tiny`)
 | `--letter-spacing <n>` | Letter spacing for filled mode (integer spaces between characters, 0+) | `1` |
 | `--reverse-gradient` | Reverse gradient colors | `false` |
 | `-l, --list-palettes` | Show all available color palettes | - |

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -83,4 +83,106 @@ describe('CLI', () => {
       }
     });
   });
+
+  describe('--filled mode options', () => {
+    it('should accept --filled flag', () => {
+      try {
+        const output = execSync(`npx tsx ${cliPath} "HI" --filled --no-color`, {
+          encoding: 'utf-8',
+        });
+        expect(output.length).toBeGreaterThan(0);
+        // Filled mode uses block characters
+        expect(output).toMatch(/[█╗╔╝╚═║]/); 
+      } catch (error: any) {
+        console.error('Error with --filled:', error.message);
+        throw error;
+      }
+    });
+
+    it('should accept --block-font option', () => {
+      try {
+        const output = execSync(`npx tsx ${cliPath} "HI" --filled --block-font chrome --no-color`, {
+          encoding: 'utf-8',
+        });
+        expect(output.length).toBeGreaterThan(0);
+        // Chrome font uses different characters
+        expect(output).toMatch(/[╦╠╩═]/); 
+      } catch (error: any) {
+        console.error('Error with --block-font:', error.message);
+        throw error;
+      }
+    });
+
+    it('should accept --letter-spacing option', () => {
+      try {
+        const output = execSync(`npx tsx ${cliPath} "AB" --filled --letter-spacing 3 --no-color`, {
+          encoding: 'utf-8',
+        });
+        expect(output.length).toBeGreaterThan(0);
+        // With spacing=3, there should be more spaces between characters
+        const lines = output.split('\n');
+        const hasWideSpacing = lines.some(line => line.includes('   '));
+        expect(hasWideSpacing).toBe(true);
+      } catch (error: any) {
+        console.error('Error with --letter-spacing:', error.message);
+        throw error;
+      }
+    });
+
+    it('should accept letter spacing of 0', () => {
+      try {
+        const output = execSync(`npx tsx ${cliPath} "AB" --filled --letter-spacing 0 --no-color`, {
+          encoding: 'utf-8',
+        });
+        expect(output.length).toBeGreaterThan(0);
+        // With spacing=0, characters should be touching with no spaces
+        // This is valid and should work
+      } catch (error: any) {
+        console.error('Error with --letter-spacing 0:', error.message);
+        throw error;
+      }
+    });
+
+    it('should reject negative letter spacing with a nice error message', () => {
+      try {
+        execSync(`npx tsx ${cliPath} "AB" --filled --letter-spacing -1`, {
+          encoding: 'utf-8',
+          stdio: 'pipe',
+        });
+        // Should not reach here
+        expect(true).toBe(false);
+      } catch (error: any) {
+        // Should fail with our custom error message
+        expect(error.stderr || error.message).toMatch(/Letter spacing must be 0 or greater/i);
+      }
+    });
+  });
+
+  describe('--reverse-gradient flag', () => {
+    it('should accept --reverse-gradient flag', () => {
+      try {
+        const output = execSync(`npx tsx ${cliPath} "TEST" --reverse-gradient --no-color`, {
+          encoding: 'utf-8',
+        });
+        expect(output.length).toBeGreaterThan(0);
+        expect(output).toMatch(/[_|\/\\]/); // Should still produce ASCII art
+      } catch (error: any) {
+        console.error('Error with --reverse-gradient:', error.message);
+        throw error;
+      }
+    });
+
+    it('should work with --filled and --reverse-gradient together', () => {
+      try {
+        const output = execSync(`npx tsx ${cliPath} "HI" --filled --reverse-gradient --no-color`, {
+          encoding: 'utf-8',
+        });
+        expect(output.length).toBeGreaterThan(0);
+        expect(output).toMatch(/[█╗╔╝╚═║]/); // Should produce filled art
+      } catch (error: any) {
+        console.error('Error with --filled --reverse-gradient:', error.message);
+        throw error;
+      }
+    });
+  });
 });

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -145,7 +145,7 @@ describe('lib', () => {
       expect(renderInkLogo).toHaveBeenCalledWith('TEST', [
         '#4ea8ff',
         '#7f88ff',
-      ]);
+      ], { font: undefined, letterSpacing: undefined });
     });
 
     it('should call renderInkLogo with custom palette', async () => {
@@ -159,7 +159,52 @@ describe('lib', () => {
         '#ff9966',
         '#ff5e62',
         '#ffa34e',
-      ]);
+      ], { font: undefined, letterSpacing: undefined });
+    });
+
+    it('should pass font option to renderInkLogo', async () => {
+      const options: RenderInkOptions = {
+        palette: 'sunset',
+        font: 'chrome',
+      };
+
+      await renderFilled('FONT', options);
+
+      expect(renderInkLogo).toHaveBeenCalledWith('FONT', [
+        '#ff9966',
+        '#ff5e62',
+        '#ffa34e',
+      ], { font: 'chrome', letterSpacing: undefined });
+    });
+
+    it('should pass letterSpacing option to renderInkLogo', async () => {
+      const options: RenderInkOptions = {
+        palette: 'grad-blue',
+        letterSpacing: 3,
+      };
+
+      await renderFilled('SPACED', options);
+
+      expect(renderInkLogo).toHaveBeenCalledWith('SPACED', [
+        '#4ea8ff',
+        '#7f88ff',
+      ], { font: undefined, letterSpacing: 3 });
+    });
+
+    it('should pass both font and letterSpacing options', async () => {
+      const options: RenderInkOptions = {
+        palette: 'sunset',
+        font: 'shade',
+        letterSpacing: 2,
+      };
+
+      await renderFilled('COMBO', options);
+
+      expect(renderInkLogo).toHaveBeenCalledWith('COMBO', [
+        '#ff9966',
+        '#ff5e62',
+        '#ffa34e',
+      ], { font: 'shade', letterSpacing: 2 });
     });
 
     it('should handle custom color arrays', async () => {
@@ -170,7 +215,7 @@ describe('lib', () => {
 
       await renderFilled('COLORS', options);
 
-      expect(renderInkLogo).toHaveBeenCalledWith('COLORS', customColors);
+      expect(renderInkLogo).toHaveBeenCalledWith('COLORS', customColors, { font: undefined, letterSpacing: undefined });
     });
 
     it('should return void (Promise<void>)', async () => {
@@ -184,6 +229,15 @@ describe('lib', () => {
       vi.mocked(renderLogo).mockRejectedValueOnce(new Error('Figlet error'));
 
       await expect(render('TEST')).rejects.toThrow('Figlet error');
+    });
+
+    it('should reject negative letter spacing in renderFilled', async () => {
+      const options: RenderInkOptions = {
+        palette: 'sunset',
+        letterSpacing: -1,
+      };
+
+      await expect(renderFilled('TEST', options)).rejects.toThrow('Letter spacing must be 0 or greater');
     });
 
     it('should handle errors from renderInkLogo', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-logo",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Display giant ASCII art logos with colorful gradients in your terminal",
   "type": "module",
   "main": "./dist/lib.js",

--- a/src/InkRenderer.tsx
+++ b/src/InkRenderer.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import { render } from 'ink';
 import BigText from 'ink-big-text';
+import type { CFontProps } from 'ink-big-text';
 import Gradient from 'ink-gradient';
 
 interface LogoProps {
   text: string;
   colors: string[];
+  font?: CFontProps['font'];
+  letterSpacing?: number;
 }
 
-const Logo: React.FC<LogoProps> = ({ text, colors }) => {
+const Logo: React.FC<LogoProps> = ({ text, colors, font = 'block', letterSpacing }) => {
   // ink-gradient with custom colors
   if (colors.length > 0) {
     return (
       <Gradient colors={colors}>
-        <BigText text={text} font="block" />
+        <BigText text={text} font={font} letterSpacing={letterSpacing} />
       </Gradient>
     );
   }
@@ -21,14 +24,14 @@ const Logo: React.FC<LogoProps> = ({ text, colors }) => {
   // Default gradient
   return (
     <Gradient name="rainbow">
-      <BigText text={text} font="block" />
+      <BigText text={text} font={font} letterSpacing={letterSpacing} />
     </Gradient>
   );
 };
 
-export function renderInkLogo(text: string, palette: string[]): Promise<void> {
+export function renderInkLogo(text: string, palette: string[], options?: { font?: CFontProps['font']; letterSpacing?: number }): Promise<void> {
   return new Promise((resolve) => {
-    const { unmount } = render(<Logo text={text} colors={palette} />);
+    const { unmount } = render(<Logo text={text} colors={palette} font={options?.font} letterSpacing={options?.letterSpacing} />);
 
     // Automatically unmount after rendering to allow process to exit
     setTimeout(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ program
     'vertical'
   )
   .option('--filled', 'Use filled characters instead of outlined ASCII art')
-  .option('--block-font <font>', 'Font for filled mode (block, chrome, shade, simpleBlock, 3d)', 'block')
+  .option('--block-font <font>', 'Font for filled mode (3d, block, chrome, grid, huge, pallet, shade, simple, simple3d, simpleBlock, slick, tiny)', 'block')
   .option('--letter-spacing <number>', 'Letter spacing for filled mode', parseInt)
   .option('--reverse-gradient', 'Reverse gradient colors')
   .action(async (text: string | undefined, paletteArg: string, options) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,9 @@ program
     'vertical'
   )
   .option('--filled', 'Use filled characters instead of outlined ASCII art')
+  .option('--block-font <font>', 'Font for filled mode (block, chrome, shade, simpleBlock, 3d)', 'block')
+  .option('--letter-spacing <number>', 'Letter spacing for filled mode', parseInt)
+  .option('--reverse-gradient', 'Reverse gradient colors')
   .action(async (text: string | undefined, paletteArg: string, options) => {
     try {
       if (options.listPalettes) {
@@ -85,13 +88,27 @@ program
         const paletteNames = getPaletteNames();
 
         for (const paletteName of paletteNames) {
-          console.log(`\n=== ${paletteName.toUpperCase()} ===\n`);
+          console.log(`\n=== ${paletteName.toUpperCase()}${options.reverseGradient ? ' (reversed)' : ''} ===\n`);
+          
+          let paletteColors = resolveColors(paletteName);
+          if (options.reverseGradient) {
+            paletteColors = [...paletteColors].reverse();
+          }
 
           if (options.filled) {
-            await renderFilled(inputText, { palette: paletteName });
+            // Validate letter spacing
+            if (options.letterSpacing !== undefined && options.letterSpacing < 0) {
+              throw new InputError('Letter spacing must be 0 or greater');
+            }
+            
+            await renderFilled(inputText, { 
+              palette: paletteColors,
+              font: options.blockFont,
+              letterSpacing: options.letterSpacing
+            });
           } else {
             const logo = await render(inputText, {
-              palette: paletteName,
+              palette: paletteColors,
               font: options.font,
               direction: options.direction,
             });
@@ -125,22 +142,38 @@ program
 
       inputText = inputText.replace(/\\n/g, '\n');
 
-      // Validate palette
+      // Validate and resolve palette
+      let paletteColors: string[];
       try {
-        resolveColors(paletteArg);
+        paletteColors = resolveColors(paletteArg);
       } catch {
         if (paletteArg !== DEFAULT_PALETTE) {
           throw new PaletteError(paletteArg);
         }
+        paletteColors = resolveColors(DEFAULT_PALETTE);
+      }
+      
+      // Reverse colors if requested
+      if (options.reverseGradient) {
+        paletteColors = [...paletteColors].reverse();
       }
 
       if (options.filled) {
+        // Validate letter spacing
+        if (options.letterSpacing !== undefined && options.letterSpacing < 0) {
+          throw new InputError('Letter spacing must be 0 or greater');
+        }
+        
         // Use Ink for filled characters
-        await renderFilled(inputText, { palette: paletteArg });
+        await renderFilled(inputText, { 
+          palette: paletteColors,
+          font: options.blockFont,
+          letterSpacing: options.letterSpacing
+        });
       } else {
         // Use figlet for outlined ASCII art
         const logo = await render(inputText, {
-          palette: paletteArg,
+          palette: paletteColors,
           font: options.font,
           direction: options.direction,
         });

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -20,8 +20,13 @@ export interface RenderOptions {
   direction?: 'vertical' | 'horizontal' | 'diagonal';
 }
 
+# cfonts upstream fonts / dir: https://github.com/dominikwilkowski/cfonts/tree/released/fonts
+export type BlockFont = '3d' | 'block' | 'chrome' | 'console' | 'grid' | 'huge' | 'pallet' | 'shade' | 'simple' | 'simple3d' | 'simpleBlock' | 'slick' | 'tiny';
+
 export interface RenderInkOptions {
   palette?: PaletteName | string[] | string;
+  font?: BlockFont;
+  letterSpacing?: number;
 }
 
 export function resolveColors(
@@ -57,9 +62,15 @@ export async function renderFilled(
   text: string,
   options: RenderInkOptions = {}
 ): Promise<void> {
-  const { palette = DEFAULT_PALETTE } = options;
+  const { palette = DEFAULT_PALETTE, font, letterSpacing } = options;
+  
+  // Validate letter spacing
+  if (letterSpacing !== undefined && letterSpacing < 0) {
+    throw new Error('Letter spacing must be 0 or greater');
+  }
+  
   const paletteColors = resolveColors(palette);
-  return renderInkLogo(text, paletteColors);
+  return renderInkLogo(text, paletteColors, { font, letterSpacing });
 }
 
 export {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -20,8 +20,9 @@ export interface RenderOptions {
   direction?: 'vertical' | 'horizontal' | 'diagonal';
 }
 
-# cfonts upstream fonts / dir: https://github.com/dominikwilkowski/cfonts/tree/released/fonts
-export type BlockFont = '3d' | 'block' | 'chrome' | 'console' | 'grid' | 'huge' | 'pallet' | 'shade' | 'simple' | 'simple3d' | 'simpleBlock' | 'slick' | 'tiny';
+// cfonts upstream fonts / dir: https://github.com/dominikwilkowski/cfonts/tree/released/fonts
+// cfont 'console' is excluded due to `Type '"console"' is not assignable to type` error/blocker
+export type BlockFont = '3d' | 'block' | 'chrome' | 'grid' | 'huge' | 'pallet' | 'shade' | 'simple' | 'simple3d' | 'simpleBlock' | 'slick' | 'tiny';
 
 export interface RenderInkOptions {
   palette?: PaletteName | string[] | string;


### PR DESCRIPTION
### 🆕 New in v0.3.0

**Customize shadow styles in filled mode:**
```bash
# Box-drawing shadows (default)
npx oh-my-logo "STYLE" fire --filled --block-font block

# Minimal sleek shadows
npx oh-my-logo "STYLE" fire --filled --block-font chrome

# Dotted/shaded shadows
npx oh-my-logo "STYLE" fire --filled --block-font shade
```

**Control letter spacing for block fonts:**
```bash
# Wide spacing (5 spaces between letters)
npx oh-my-logo "WIDE" ocean --filled --letter-spacing 5

# Tight spacing (no spaces)
npx oh-my-logo "TIGHT" ocean --filled --letter-spacing 0
```

**Reverse gradients for unique effects:**
```bash
# Reverse any color palette
npx oh-my-logo "REVERSE" sunset --reverse-gradient

# Works with filled mode too
npx oh-my-logo "REVERSE" sunset --filled --reverse-gradient
```