### PR TITLE
Fix terminal corruption issue with --filled mode (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,26 @@ Tests are located in `src/__tests__/` with the following structure:
 - `renderer.test.ts` - ASCII art rendering
 - `utils/` - Utility function tests
 
+### Testing Terminal Stability
+
+A test script is provided to verify that the `--filled` mode properly cleans up terminal state:
+
+```bash
+# Run terminal stability stress test
+./scripts/test-filled-mode.sh
+```
+
+This script:
+- Runs 55 consecutive renders (5 iterations × 11 fonts)
+- Tests all available fonts with random color palettes
+- Verifies terminal display remains intact after extensive use
+- Helps detect any terminal corruption issues
+
+This is particularly useful for:
+- Testing after making changes to the Ink renderer
+- Verifying terminal compatibility with different environments
+- Stress testing the `--filled` mode implementation
+
 ### Adding New Palettes
 
 Edit `src/palettes.ts` to add your own color combinations:

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -92,7 +92,7 @@ describe('CLI', () => {
         });
         expect(output.length).toBeGreaterThan(0);
         // Filled mode uses block characters
-        expect(output).toMatch(/[█╗╔╝╚═║]/); 
+        expect(output).toMatch(/[█╗╔╝╚═║]/);
       } catch (error: any) {
         console.error('Error with --filled:', error.message);
         throw error;
@@ -101,12 +101,15 @@ describe('CLI', () => {
 
     it('should accept --block-font option', () => {
       try {
-        const output = execSync(`npx tsx ${cliPath} "HI" --filled --block-font chrome --no-color`, {
-          encoding: 'utf-8',
-        });
+        const output = execSync(
+          `npx tsx ${cliPath} "HI" --filled --block-font chrome --no-color`,
+          {
+            encoding: 'utf-8',
+          }
+        );
         expect(output.length).toBeGreaterThan(0);
         // Chrome font uses different characters
-        expect(output).toMatch(/[╦╠╩═]/); 
+        expect(output).toMatch(/[╦╠╩═]/);
       } catch (error: any) {
         console.error('Error with --block-font:', error.message);
         throw error;
@@ -115,13 +118,16 @@ describe('CLI', () => {
 
     it('should accept --letter-spacing option', () => {
       try {
-        const output = execSync(`npx tsx ${cliPath} "AB" --filled --letter-spacing 3 --no-color`, {
-          encoding: 'utf-8',
-        });
+        const output = execSync(
+          `npx tsx ${cliPath} "AB" --filled --letter-spacing 3 --no-color`,
+          {
+            encoding: 'utf-8',
+          }
+        );
         expect(output.length).toBeGreaterThan(0);
         // With spacing=3, there should be more spaces between characters
         const lines = output.split('\n');
-        const hasWideSpacing = lines.some(line => line.includes('   '));
+        const hasWideSpacing = lines.some((line) => line.includes('   '));
         expect(hasWideSpacing).toBe(true);
       } catch (error: any) {
         console.error('Error with --letter-spacing:', error.message);
@@ -131,9 +137,12 @@ describe('CLI', () => {
 
     it('should accept letter spacing of 0', () => {
       try {
-        const output = execSync(`npx tsx ${cliPath} "AB" --filled --letter-spacing 0 --no-color`, {
-          encoding: 'utf-8',
-        });
+        const output = execSync(
+          `npx tsx ${cliPath} "AB" --filled --letter-spacing 0 --no-color`,
+          {
+            encoding: 'utf-8',
+          }
+        );
         expect(output.length).toBeGreaterThan(0);
         // With spacing=0, characters should be touching with no spaces
         // This is valid and should work
@@ -153,7 +162,9 @@ describe('CLI', () => {
         expect(true).toBe(false);
       } catch (error: any) {
         // Should fail with our custom error message
-        expect(error.stderr || error.message).toMatch(/Letter spacing must be 0 or greater/i);
+        expect(error.stderr || error.message).toMatch(
+          /Letter spacing must be 0 or greater/i
+        );
       }
     });
   });
@@ -161,9 +172,12 @@ describe('CLI', () => {
   describe('--reverse-gradient flag', () => {
     it('should accept --reverse-gradient flag', () => {
       try {
-        const output = execSync(`npx tsx ${cliPath} "TEST" --reverse-gradient --no-color`, {
-          encoding: 'utf-8',
-        });
+        const output = execSync(
+          `npx tsx ${cliPath} "TEST" --reverse-gradient --no-color`,
+          {
+            encoding: 'utf-8',
+          }
+        );
         expect(output.length).toBeGreaterThan(0);
         expect(output).toMatch(/[_|\/\\]/); // Should still produce ASCII art
       } catch (error: any) {
@@ -174,9 +188,12 @@ describe('CLI', () => {
 
     it('should work with --filled and --reverse-gradient together', () => {
       try {
-        const output = execSync(`npx tsx ${cliPath} "HI" --filled --reverse-gradient --no-color`, {
-          encoding: 'utf-8',
-        });
+        const output = execSync(
+          `npx tsx ${cliPath} "HI" --filled --reverse-gradient --no-color`,
+          {
+            encoding: 'utf-8',
+          }
+        );
         expect(output.length).toBeGreaterThan(0);
         expect(output).toMatch(/[█╗╔╝╚═║]/); // Should produce filled art
       } catch (error: any) {

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -142,10 +142,11 @@ describe('lib', () => {
     it('should call renderInkLogo with default palette', async () => {
       await renderFilled('TEST');
 
-      expect(renderInkLogo).toHaveBeenCalledWith('TEST', [
-        '#4ea8ff',
-        '#7f88ff',
-      ], { font: undefined, letterSpacing: undefined });
+      expect(renderInkLogo).toHaveBeenCalledWith(
+        'TEST',
+        ['#4ea8ff', '#7f88ff'],
+        { font: undefined, letterSpacing: undefined }
+      );
     });
 
     it('should call renderInkLogo with custom palette', async () => {
@@ -155,11 +156,11 @@ describe('lib', () => {
 
       await renderFilled('FILLED', options);
 
-      expect(renderInkLogo).toHaveBeenCalledWith('FILLED', [
-        '#ff9966',
-        '#ff5e62',
-        '#ffa34e',
-      ], { font: undefined, letterSpacing: undefined });
+      expect(renderInkLogo).toHaveBeenCalledWith(
+        'FILLED',
+        ['#ff9966', '#ff5e62', '#ffa34e'],
+        { font: undefined, letterSpacing: undefined }
+      );
     });
 
     it('should pass font option to renderInkLogo', async () => {
@@ -170,11 +171,11 @@ describe('lib', () => {
 
       await renderFilled('FONT', options);
 
-      expect(renderInkLogo).toHaveBeenCalledWith('FONT', [
-        '#ff9966',
-        '#ff5e62',
-        '#ffa34e',
-      ], { font: 'chrome', letterSpacing: undefined });
+      expect(renderInkLogo).toHaveBeenCalledWith(
+        'FONT',
+        ['#ff9966', '#ff5e62', '#ffa34e'],
+        { font: 'chrome', letterSpacing: undefined }
+      );
     });
 
     it('should pass letterSpacing option to renderInkLogo', async () => {
@@ -185,10 +186,11 @@ describe('lib', () => {
 
       await renderFilled('SPACED', options);
 
-      expect(renderInkLogo).toHaveBeenCalledWith('SPACED', [
-        '#4ea8ff',
-        '#7f88ff',
-      ], { font: undefined, letterSpacing: 3 });
+      expect(renderInkLogo).toHaveBeenCalledWith(
+        'SPACED',
+        ['#4ea8ff', '#7f88ff'],
+        { font: undefined, letterSpacing: 3 }
+      );
     });
 
     it('should pass both font and letterSpacing options', async () => {
@@ -200,11 +202,11 @@ describe('lib', () => {
 
       await renderFilled('COMBO', options);
 
-      expect(renderInkLogo).toHaveBeenCalledWith('COMBO', [
-        '#ff9966',
-        '#ff5e62',
-        '#ffa34e',
-      ], { font: 'shade', letterSpacing: 2 });
+      expect(renderInkLogo).toHaveBeenCalledWith(
+        'COMBO',
+        ['#ff9966', '#ff5e62', '#ffa34e'],
+        { font: 'shade', letterSpacing: 2 }
+      );
     });
 
     it('should handle custom color arrays', async () => {
@@ -215,7 +217,10 @@ describe('lib', () => {
 
       await renderFilled('COLORS', options);
 
-      expect(renderInkLogo).toHaveBeenCalledWith('COLORS', customColors, { font: undefined, letterSpacing: undefined });
+      expect(renderInkLogo).toHaveBeenCalledWith('COLORS', customColors, {
+        font: undefined,
+        letterSpacing: undefined,
+      });
     });
 
     it('should return void (Promise<void>)', async () => {
@@ -237,7 +242,9 @@ describe('lib', () => {
         letterSpacing: -1,
       };
 
-      await expect(renderFilled('TEST', options)).rejects.toThrow('Letter spacing must be 0 or greater');
+      await expect(renderFilled('TEST', options)).rejects.toThrow(
+        'Letter spacing must be 0 or greater'
+      );
     });
 
     it('should handle errors from renderInkLogo', async () => {

--- a/__tests__/terminal-cleanup.test.ts
+++ b/__tests__/terminal-cleanup.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderInkLogo } from '../src/InkRenderer.js';
+
+vi.mock('ink', () => ({
+  render: vi.fn(() => ({
+    unmount: vi.fn(),
+  })),
+}));
+
+vi.mock('ink-big-text', () => ({
+  default: vi.fn(() => null),
+}));
+
+vi.mock('ink-gradient', () => ({
+  default: vi.fn(({ children }: any) => children),
+}));
+
+describe('Terminal cleanup after filled mode', () => {
+  let stdoutWriteSpy: any;
+  let originalWrite: any;
+  const writtenData: string[] = [];
+  
+  beforeEach(() => {
+    writtenData.length = 0;
+    originalWrite = process.stdout.write;
+    stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation((data: any) => {
+      if (typeof data === 'string') {
+        writtenData.push(data);
+      }
+      return true;
+    });
+  });
+  
+  afterEach(() => {
+    stdoutWriteSpy.mockRestore();
+    process.stdout.write = originalWrite;
+  });
+
+  it('should output ANSI reset sequences after rendering', async () => {
+    await renderInkLogo('TEST', ['#ff0000', '#00ff00']);
+    
+    // Check that reset sequences were written
+    const output = writtenData.join('');
+    
+    // SGR reset (colors, styles)
+    expect(output).toContain('\x1b[0m');
+    // Cursor visibility restore
+    expect(output).toContain('\x1b[?25h');
+    // Clear to end of line
+    expect(output).toContain('\x1b[K');
+  });
+
+  it('should handle multiple consecutive renders without accumulating issues', async () => {
+    // Run multiple renders
+    for (let i = 0; i < 5; i++) {
+      writtenData.length = 0; // Clear for each iteration
+      await renderInkLogo(`TEST${i}`, ['#ff0000', '#00ff00']);
+      
+      // Each render should output cleanup codes
+      const output = writtenData.join('');
+      expect(output).toContain('\x1b[0m');
+      expect(output).toContain('\x1b[?25h');
+    }
+  });
+
+  it('should clean up even with different fonts', async () => {
+    const fonts = ['block', 'chrome', 'grid'] as const;
+    
+    for (const font of fonts) {
+      writtenData.length = 0;
+      await renderInkLogo('TEST', ['#ff0000'], { font });
+      
+      const output = writtenData.join('');
+      expect(output).toContain('\x1b[0m');
+      expect(output).toContain('\x1b[?25h');
+      expect(output).toContain('\x1b[K');
+    }
+  });
+
+  it('should clean up with letter spacing options', async () => {
+    await renderInkLogo('TEST', ['#ff0000'], { letterSpacing: 2 });
+    
+    const output = writtenData.join('');
+    expect(output).toContain('\x1b[0m');
+    expect(output).toContain('\x1b[?25h');
+    expect(output).toContain('\x1b[K');
+  });
+
+  it('should output cleanup codes', async () => {
+    await renderInkLogo('TEST', ['#ff0000']);
+    
+    // Find indices of each cleanup code
+    const output = writtenData.join('');
+    const sgrResetIndex = output.indexOf('\x1b[0m');
+    const cursorShowIndex = output.indexOf('\x1b[?25h');
+    const clearLineIndex = output.indexOf('\x1b[K');
+    
+    // All cleanup codes should be present
+    expect(sgrResetIndex).toBeGreaterThanOrEqual(0);
+    expect(cursorShowIndex).toBeGreaterThanOrEqual(0);
+    expect(clearLineIndex).toBeGreaterThanOrEqual(0);
+    
+    // Verify they are output in sequence (since mocked render doesn't output actual content)
+    expect(output).toMatch(/\x1b\[0m.*\x1b\[\?25h.*\x1b\[K/s);
+  });
+});

--- a/__tests__/terminal-cleanup.test.ts
+++ b/__tests__/terminal-cleanup.test.ts
@@ -19,18 +19,20 @@ describe('Terminal cleanup after filled mode', () => {
   let stdoutWriteSpy: any;
   let originalWrite: any;
   const writtenData: string[] = [];
-  
+
   beforeEach(() => {
     writtenData.length = 0;
     originalWrite = process.stdout.write;
-    stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation((data: any) => {
-      if (typeof data === 'string') {
-        writtenData.push(data);
-      }
-      return true;
-    });
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((data: any) => {
+        if (typeof data === 'string') {
+          writtenData.push(data);
+        }
+        return true;
+      });
   });
-  
+
   afterEach(() => {
     stdoutWriteSpy.mockRestore();
     process.stdout.write = originalWrite;
@@ -38,10 +40,10 @@ describe('Terminal cleanup after filled mode', () => {
 
   it('should output ANSI reset sequences after rendering', async () => {
     await renderInkLogo('TEST', ['#ff0000', '#00ff00']);
-    
+
     // Check that reset sequences were written
     const output = writtenData.join('');
-    
+
     // SGR reset (colors, styles)
     expect(output).toContain('\x1b[0m');
     // Cursor visibility restore
@@ -55,7 +57,7 @@ describe('Terminal cleanup after filled mode', () => {
     for (let i = 0; i < 5; i++) {
       writtenData.length = 0; // Clear for each iteration
       await renderInkLogo(`TEST${i}`, ['#ff0000', '#00ff00']);
-      
+
       // Each render should output cleanup codes
       const output = writtenData.join('');
       expect(output).toContain('\x1b[0m');
@@ -65,11 +67,11 @@ describe('Terminal cleanup after filled mode', () => {
 
   it('should clean up even with different fonts', async () => {
     const fonts = ['block', 'chrome', 'grid'] as const;
-    
+
     for (const font of fonts) {
       writtenData.length = 0;
       await renderInkLogo('TEST', ['#ff0000'], { font });
-      
+
       const output = writtenData.join('');
       expect(output).toContain('\x1b[0m');
       expect(output).toContain('\x1b[?25h');
@@ -79,7 +81,7 @@ describe('Terminal cleanup after filled mode', () => {
 
   it('should clean up with letter spacing options', async () => {
     await renderInkLogo('TEST', ['#ff0000'], { letterSpacing: 2 });
-    
+
     const output = writtenData.join('');
     expect(output).toContain('\x1b[0m');
     expect(output).toContain('\x1b[?25h');
@@ -88,18 +90,18 @@ describe('Terminal cleanup after filled mode', () => {
 
   it('should output cleanup codes', async () => {
     await renderInkLogo('TEST', ['#ff0000']);
-    
+
     // Find indices of each cleanup code
     const output = writtenData.join('');
     const sgrResetIndex = output.indexOf('\x1b[0m');
     const cursorShowIndex = output.indexOf('\x1b[?25h');
     const clearLineIndex = output.indexOf('\x1b[K');
-    
+
     // All cleanup codes should be present
     expect(sgrResetIndex).toBeGreaterThanOrEqual(0);
     expect(cursorShowIndex).toBeGreaterThanOrEqual(0);
     expect(clearLineIndex).toBeGreaterThanOrEqual(0);
-    
+
     // Verify they are output in sequence (since mocked render doesn't output actual content)
     expect(output).toMatch(/\x1b\[0m.*\x1b\[\?25h.*\x1b\[K/s);
   });

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,43 @@
+# Development Scripts
+
+This directory contains utility scripts for development and testing of oh-my-logo.
+
+## Available Scripts
+
+### test-filled-mode.sh
+
+**Purpose**: Stress test for the `--filled` mode terminal cleanup functionality.
+
+**Context**: This script was created to address [Issue #16](https://github.com/shinshin86/oh-my-logo/issues/16) - Terminal corruption after extensive use of `--filled` mode.
+
+**Usage**:
+```bash
+./scripts/test-filled-mode.sh
+```
+
+**What it does**:
+- Builds the project
+- Runs 55 consecutive renders (5 iterations × 11 fonts)
+- Tests all available block fonts with random color palettes
+- Displays verification text to check for terminal corruption
+- Helps ensure that ANSI escape sequences are properly reset
+
+**When to use**:
+- After modifying the Ink renderer (`src/InkRenderer.tsx`)
+- When testing terminal compatibility with different environments
+- To verify that terminal state cleanup is working correctly
+- Before releasing changes that affect the `--filled` mode
+
+**Expected output**:
+After all iterations complete, the verification text (ASCII, Unicode, Japanese, box drawing characters) should display correctly without any corruption or artifacts.
+
+## Adding New Scripts
+
+When adding new development scripts:
+1. Place them in this `scripts/` directory
+2. Make them executable: `chmod +x scripts/your-script.sh`
+3. Document them in this README with:
+   - Purpose
+   - Usage instructions
+   - When to use
+   - Expected behavior

--- a/scripts/test-filled-mode.sh
+++ b/scripts/test-filled-mode.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Test script for filled mode terminal corruption issue (#16)
+# This script runs oh-my-logo multiple times with different fonts and colors
+# to verify that terminal state is properly reset after each execution
+
+echo "Starting filled mode stress test..."
+echo "This test will run oh-my-logo with all available fonts multiple times"
+echo "Watch for any terminal corruption or display issues"
+echo ""
+
+# Build the project first
+echo "Building project..."
+npm run build
+
+echo ""
+echo "=== Starting test iterations ==="
+echo ""
+
+# List of all available fonts
+FONTS=(block chrome grid huge pallet shade simple simple3d simpleBlock slick tiny)
+PALETTES=(grad-blue sunset dawn nebula mono ocean fire forest gold purple mint coral matrix)
+
+# Run multiple iterations
+for iteration in {1..5}; do
+  echo "--- Iteration $iteration of 5 ---"
+  
+  # Test each font
+  for font in "${FONTS[@]}"; do
+    # Pick a random palette for variety
+    palette=${PALETTES[$RANDOM % ${#PALETTES[@]}]}
+    
+    echo "Testing font: $font with palette: $palette"
+    node dist/index.js "TEST" "$palette" --filled --block-font "$font"
+    
+    # Small delay to allow terminal to process
+    sleep 0.1
+  done
+  
+  echo ""
+done
+
+echo "=== Test completed ==="
+echo ""
+echo "Verification checks:"
+echo "1. Normal ASCII text: ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+echo "2. Numbers: 0123456789"
+echo "3. Special characters: !@#$%^&*()"
+echo "4. Unicode test: ✓ ✗ ★ ☆ ♥ ♦ ♣ ♠"
+echo "5. Japanese text: これは正常に表示されていますか？"
+echo "6. Box drawing: ┌─┬─┐ │ │ │ ├─┼─┤ │ │ │ └─┴─┘"
+echo ""
+echo "If all the above text displays correctly, the terminal cleanup is working properly."
+echo "If you see corrupted characters, the issue persists."

--- a/src/InkRenderer.tsx
+++ b/src/InkRenderer.tsx
@@ -36,6 +36,15 @@ export function renderInkLogo(text: string, palette: string[], options?: { font?
     // Automatically unmount after rendering to allow process to exit
     setTimeout(() => {
       unmount();
+      
+      // Reset terminal state to prevent corruption
+      // SGR reset (colors, styles)
+      process.stdout.write('\x1b[0m');
+      // Ensure cursor is visible
+      process.stdout.write('\x1b[?25h');
+      // Clear to end of line to remove any artifacts
+      process.stdout.write('\x1b[K');
+      
       resolve();
     }, 100);
   });

--- a/src/InkRenderer.tsx
+++ b/src/InkRenderer.tsx
@@ -11,7 +11,12 @@ interface LogoProps {
   letterSpacing?: number;
 }
 
-const Logo: React.FC<LogoProps> = ({ text, colors, font = 'block', letterSpacing }) => {
+const Logo: React.FC<LogoProps> = ({
+  text,
+  colors,
+  font = 'block',
+  letterSpacing,
+}) => {
   // ink-gradient with custom colors
   if (colors.length > 0) {
     return (
@@ -29,14 +34,25 @@ const Logo: React.FC<LogoProps> = ({ text, colors, font = 'block', letterSpacing
   );
 };
 
-export function renderInkLogo(text: string, palette: string[], options?: { font?: CFontProps['font']; letterSpacing?: number }): Promise<void> {
+export function renderInkLogo(
+  text: string,
+  palette: string[],
+  options?: { font?: CFontProps['font']; letterSpacing?: number }
+): Promise<void> {
   return new Promise((resolve) => {
-    const { unmount } = render(<Logo text={text} colors={palette} font={options?.font} letterSpacing={options?.letterSpacing} />);
+    const { unmount } = render(
+      <Logo
+        text={text}
+        colors={palette}
+        font={options?.font}
+        letterSpacing={options?.letterSpacing}
+      />
+    );
 
     // Automatically unmount after rendering to allow process to exit
     setTimeout(() => {
       unmount();
-      
+
       // Reset terminal state to prevent corruption
       // SGR reset (colors, styles)
       process.stdout.write('\x1b[0m');
@@ -44,7 +60,7 @@ export function renderInkLogo(text: string, palette: string[], options?: { font?
       process.stdout.write('\x1b[?25h');
       // Clear to end of line to remove any artifacts
       process.stdout.write('\x1b[K');
-      
+
       resolve();
     }, 100);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,16 @@ program
     'vertical'
   )
   .option('--filled', 'Use filled characters instead of outlined ASCII art')
-  .option('--block-font <font>', 'Font for filled mode (3d, block, chrome, grid, huge, pallet, shade, simple, simple3d, simpleBlock, slick, tiny)', 'block')
-  .option('--letter-spacing <number>', 'Letter spacing for filled mode', parseInt)
+  .option(
+    '--block-font <font>',
+    'Font for filled mode (3d, block, chrome, grid, huge, pallet, shade, simple, simple3d, simpleBlock, slick, tiny)',
+    'block'
+  )
+  .option(
+    '--letter-spacing <number>',
+    'Letter spacing for filled mode',
+    parseInt
+  )
   .option('--reverse-gradient', 'Reverse gradient colors')
   .action(async (text: string | undefined, paletteArg: string, options) => {
     try {
@@ -88,8 +96,10 @@ program
         const paletteNames = getPaletteNames();
 
         for (const paletteName of paletteNames) {
-          console.log(`\n=== ${paletteName.toUpperCase()}${options.reverseGradient ? ' (reversed)' : ''} ===\n`);
-          
+          console.log(
+            `\n=== ${paletteName.toUpperCase()}${options.reverseGradient ? ' (reversed)' : ''} ===\n`
+          );
+
           let paletteColors = resolveColors(paletteName);
           if (options.reverseGradient) {
             paletteColors = [...paletteColors].reverse();
@@ -97,14 +107,17 @@ program
 
           if (options.filled) {
             // Validate letter spacing
-            if (options.letterSpacing !== undefined && options.letterSpacing < 0) {
+            if (
+              options.letterSpacing !== undefined &&
+              options.letterSpacing < 0
+            ) {
               throw new InputError('Letter spacing must be 0 or greater');
             }
-            
-            await renderFilled(inputText, { 
+
+            await renderFilled(inputText, {
               palette: paletteColors,
               font: options.blockFont,
-              letterSpacing: options.letterSpacing
+              letterSpacing: options.letterSpacing,
             });
           } else {
             const logo = await render(inputText, {
@@ -152,7 +165,7 @@ program
         }
         paletteColors = resolveColors(DEFAULT_PALETTE);
       }
-      
+
       // Reverse colors if requested
       if (options.reverseGradient) {
         paletteColors = [...paletteColors].reverse();
@@ -163,12 +176,12 @@ program
         if (options.letterSpacing !== undefined && options.letterSpacing < 0) {
           throw new InputError('Letter spacing must be 0 or greater');
         }
-        
+
         // Use Ink for filled characters
-        await renderFilled(inputText, { 
+        await renderFilled(inputText, {
           palette: paletteColors,
           font: options.blockFont,
-          letterSpacing: options.letterSpacing
+          letterSpacing: options.letterSpacing,
         });
       } else {
         // Use figlet for outlined ASCII art

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -22,7 +22,19 @@ export interface RenderOptions {
 
 // cfonts upstream fonts / dir: https://github.com/dominikwilkowski/cfonts/tree/released/fonts
 // cfont 'console' is excluded due to `Type '"console"' is not assignable to type` error/blocker
-export type BlockFont = '3d' | 'block' | 'chrome' | 'grid' | 'huge' | 'pallet' | 'shade' | 'simple' | 'simple3d' | 'simpleBlock' | 'slick' | 'tiny';
+export type BlockFont =
+  | '3d'
+  | 'block'
+  | 'chrome'
+  | 'grid'
+  | 'huge'
+  | 'pallet'
+  | 'shade'
+  | 'simple'
+  | 'simple3d'
+  | 'simpleBlock'
+  | 'slick'
+  | 'tiny';
 
 export interface RenderInkOptions {
   palette?: PaletteName | string[] | string;
@@ -64,12 +76,12 @@ export async function renderFilled(
   options: RenderInkOptions = {}
 ): Promise<void> {
   const { palette = DEFAULT_PALETTE, font, letterSpacing } = options;
-  
+
   // Validate letter spacing
   if (letterSpacing !== undefined && letterSpacing < 0) {
     throw new Error('Letter spacing must be 0 or greater');
   }
-  
+
   const paletteColors = resolveColors(palette);
   return renderInkLogo(text, paletteColors, { font, letterSpacing });
 }


### PR DESCRIPTION
Fix terminal corruption issue with --filled mode (#16)

This commit addresses the terminal display corruption reported when using the `--filled` mode extensively with various fonts and colors.

## Changes made:

- Add ANSI reset sequences to InkRenderer.tsx after unmounting
  - SGR reset (\x1b[0m) to clear colors and styles
  - Cursor visibility restore (\x1b[?25h)
  - Clear to end of line (\x1b[K) to remove artifacts

- Add comprehensive test coverage for terminal cleanup
  - New test file: `__tests__/terminal-cleanup.test.ts`
  - Verifies cleanup sequences are output correctly

- Add terminal stability stress test script
  - `scripts/test-filled-mode.sh` for manual verification
  - Tests 55 consecutive renders with all fonts
  - Includes verification text to check for corruption

This ensures terminal state is properly reset after each `--filled` mode execution, preventing the accumulation of escape sequences that cause display corruption.

Fixes https://github.com/shinshin86/oh-my-logo/issues/16